### PR TITLE
Use recarray

### DIFF
--- a/.idea/BoMI-StartReact.iml
+++ b/.idea/BoMI-StartReact.iml
@@ -18,5 +18,6 @@
   <component name="PyDocumentationSettings">
     <option name="format" value="PLAIN" />
     <option name="myDocStringFormat" value="Plain" />
+    <option name="renderExternalDocumentation" value="true" />
   </component>
 </module>

--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PySciProjectComponent">
+    <option name="PY_SCI_VIEW" value="true" />
+    <option name="PY_SCI_VIEW_SUGGESTED" value="true" />
+  </component>
+</project>

--- a/bomi/datastructure.py
+++ b/bomi/datastructure.py
@@ -58,8 +58,8 @@ class MultichannelBuffer:
         # name of this device
         self.name: str = name
 
-        self._angle_in_use: int = -1  # idx of the labelled angle in use
-        self.last_angle: float = 0.0  # angle used for task purposes
+        self._channel_index: int = -1  # index of the labelled channel in use
+        self.last_measurement: float = 0.0  # last measurement from the channel selected for the task
 
         self.savedir: Path = savedir
         header = ",".join(("t", *self.channel_labels)) + "\n"
@@ -74,7 +74,7 @@ class MultichannelBuffer:
 
     def set_angle_type(self, label: str):
         i = self.channel_labels.index(label)
-        self._angle_in_use = i
+        self._channel_index = i
 
     def add_packet(self, packet: dict[str, int | float]):
         "Add `Packet` of sensor data"
@@ -89,7 +89,7 @@ class MultichannelBuffer:
         self.timestamp[:-1] = self.timestamp[1:]
         self.timestamp[-1] = packet["Time"]
 
-        self.last_angle = _packet[self._angle_in_use]
+        self.last_measurement = _packet[self._channel_index]
 
 
 class DelsysBuffer:

--- a/bomi/datastructure.py
+++ b/bomi/datastructure.py
@@ -33,7 +33,7 @@ class SubjectMetadata:
         return asdict(self)
 
     def to_disk(self, savedir: Path):
-        "Write metadata to `savedir`"
+        """Write metadata to `savedir`"""
         with (savedir / "meta.json").open("w") as fp:
             json.dump(asdict(self), fp, indent=2)
 
@@ -51,10 +51,8 @@ class MultichannelBuffer:
         # 2D array of `labels`
         self.data: np.ndarray = np.zeros((bufsize, len(self.channel_labels)))
 
-        fp = open(savedir / f"{input_kind}_{name}.csv", "w")
-
-        # filepointer to write CSV data to
-        self.sensor_fp: TextIO = fp
+        # file pointer to write CSV data to
+        self.sensor_fp: TextIO = open(savedir / f"{input_kind}_{name}.csv", "w")
         # name of this device
         self.name: str = name
 
@@ -69,7 +67,7 @@ class MultichannelBuffer:
         return len(self.data)
 
     def __del__(self):
-        "Close open file pointers"
+        """Close open file pointers"""
         self.sensor_fp.close()
 
     def set_angle_type(self, label: str):
@@ -77,13 +75,13 @@ class MultichannelBuffer:
         self._channel_index = i
 
     def add_packet(self, packet: dict[str, int | float]):
-        "Add `Packet` of sensor data"
+        """Add `Packet` of sensor data"""
         _packet = [packet[key] for key in self.channel_labels]
 
         # Write to file pointer
         self.sensor_fp.write(",".join((str(v) for v in (packet["Time"], *_packet))) + "\n")
 
-        ### Shift buffer when full, never changing buffer size
+        # Shift buffer when full, never changing buffer size
         self.data[:-1] = self.data[1:]
         self.data[-1] = _packet
         self.timestamp[:-1] = self.timestamp[1:]
@@ -107,7 +105,7 @@ class DelsysBuffer:
     def add_packet(self, packet: Tuple[float, ...]):
         # assert len(packet) == 16
 
-        ### Shift buffer when full, never changing buffer size
+        # Shift buffer when full, never changing buffer size
         self.data[:-1] = self.data[1:]
         self.data[-1] = packet
         self.timestamp[:-1] = self.timestamp[1:]
@@ -116,7 +114,6 @@ class DelsysBuffer:
     def add_packets(self, packets: np.ndarray):
         n = len(packets)
 
-        ### Shift buffer when full, never changing buffer size
         self.data[:-n] = self.data[n:]
         self.data[-n:] = packets
         self.timestamp[:-n] = self.timestamp[n:]

--- a/bomi/datastructure.py
+++ b/bomi/datastructure.py
@@ -76,7 +76,7 @@ class MultichannelBuffer:
 
     def add_packet(self, packet: dict[str, int | float]):
         """Add `Packet` of sensor data"""
-        _packet = [packet[key] for key in self.channel_labels]
+        _packet = tuple(packet[key] for key in self.channel_labels)
 
         # Write to file pointer
         self.sensor_fp.write(",".join((str(v) for v in (packet["Time"], *_packet))) + "\n")

--- a/bomi/scope_widget.py
+++ b/bomi/scope_widget.py
@@ -480,10 +480,6 @@ class ScopeWidget(qw.QWidget):
                 input_kind=self.dm.INPUT_KIND,
                 channel_labels=self.dm.CHANNEL_LABELS
             )
-            if self.task_widget:
-                self.buffers[device_name].set_angle_type(
-                    self.task_widget.selected_channel
-                )  # type: ignore
 
     def init_ui(self):
         ### Init UI
@@ -623,8 +619,8 @@ class ScopeWidget(qw.QWidget):
             curves = self.plot_handles[name].curves
 
             x = -(now - buf.timestamp)
-            for i, label in enumerate(self.dm.CHANNEL_LABELS):
-                curves[label].setData(x=x, y=buf.data[:, i])
+            for label in self.dm.CHANNEL_LABELS:
+                curves[label].setData(x=x, y=buf.data[label])
 
         ### Update task states if needed
         # 1. Check if angle is within target range
@@ -633,7 +629,7 @@ class ScopeWidget(qw.QWidget):
             tmin, tmax = self.target_range
             bmin, bmax = self.base_range
             for name in self.dev_names:
-                angle = self.buffers[name].last_measurement
+                angle = self.buffers[name].data[self.task_widget.selected_channel][-1]
 
                 if self.last_state == AngleState.IN_TARGET:
                     if not tmin <= angle <= tmax:

--- a/bomi/scope_widget.py
+++ b/bomi/scope_widget.py
@@ -633,7 +633,7 @@ class ScopeWidget(qw.QWidget):
             tmin, tmax = self.target_range
             bmin, bmax = self.base_range
             for name in self.dev_names:
-                angle = self.buffers[name].last_angle
+                angle = self.buffers[name].last_measurement
 
                 if self.last_state == AngleState.IN_TARGET:
                     if not tmin <= angle <= tmax:

--- a/bomi/scope_widget.py
+++ b/bomi/scope_widget.py
@@ -603,14 +603,17 @@ class ScopeWidget(qw.QWidget):
 
         for _ in range(qsize):  # process current items in queue
             packet = q.get()
+            
+            name = packet["Name"]
             try:
-                self.buffers[packet["Name"]].add_packet(packet)
+                buffer = self.buffers[name]
             except KeyError:
                 # When we select a single sensor,
                 # the device manager will still populate the queue
                 # with packets from the other sensors (not ideal).
                 # Ignore these.
-                pass
+                continue
+            buffer.add_packet(packet)
 
         # On successful read from queue, update curves
         now = default_timer()


### PR DESCRIPTION
This removes the need for storing the selected channel and updating the last measurement for a given task in the MultichannelBuffer class.

Instead, the calling code can use buffer.data[channel][-1].