### PR TITLE
Use generalized Packet class

### DIFF
--- a/bomi/datastructure.py
+++ b/bomi/datastructure.py
@@ -5,7 +5,7 @@ from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 from timeit import default_timer
-from typing import TextIO, Tuple
+from typing import TextIO, Tuple, Any
 
 import numpy as np
 
@@ -36,6 +36,32 @@ class SubjectMetadata:
         """Write metadata to `savedir`"""
         with (savedir / "meta.json").open("w") as fp:
             json.dump(asdict(self), fp, indent=2)
+
+
+@dataclass(frozen=True)
+class Packet:
+    """
+    Represents a packet of data from an individual sensor.
+    """
+
+    time: float
+    """
+    The time that this packet object was created,
+    as returned by timeit.default_timer().
+    """
+
+    device_name: str
+    """
+    The name of the device that reported the data
+    in this packet.
+    """
+
+    channel_readings: dict[str, Any]
+    """
+    A dictionary of the channel readings,
+    where the keys are the device's channel labels,
+    and the values are the readings.
+    """
 
 
 class MultichannelBuffer:

--- a/bomi/datastructure.py
+++ b/bomi/datastructure.py
@@ -100,18 +100,18 @@ class MultichannelBuffer:
         """Close open file pointers"""
         self.sensor_fp.close()
 
-    def add_packet(self, packet: dict[str, int | float]):
+    def add_packet(self, packet: Packet):
         """Add `Packet` of sensor data"""
-        _packet = tuple(packet[key] for key in self.channel_labels)
+        readings = tuple(packet.channel_readings[key] for key in self.channel_labels)
 
         # Write to file pointer
-        self.sensor_fp.write(",".join((str(v) for v in (packet["Time"], *_packet))) + "\n")
+        self.sensor_fp.write(",".join((str(v) for v in (packet.time, *readings))) + "\n")
 
         # Shift buffer when full, never changing buffer size
         self.data[:-1] = self.data[1:]
-        self.data[-1] = _packet
+        self.data[-1] = readings
         self.timestamp[:-1] = self.timestamp[1:]
-        self.timestamp[-1] = packet["Time"]
+        self.timestamp[-1] = packet.time
 
 
 class DelsysBuffer:

--- a/bomi/device_managers/protocols.py
+++ b/bomi/device_managers/protocols.py
@@ -2,9 +2,11 @@ from typing import Protocol, Sequence, ClassVar
 from queue import Queue
 from PySide6.QtCore import Signal
 
+from bomi.datastructure import Packet
+
 
 class SupportsStreaming(Protocol):
-    def start_stream(self, queue: Queue) -> None:
+    def start_stream(self, queue: Queue[Packet]) -> None:
         """
         Start streaming data to the passed in queue
         """

--- a/bomi/device_managers/qtm_manager.py
+++ b/bomi/device_managers/qtm_manager.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import time
 import bomi.device_managers.analog_streaming_client as AS
+from bomi.datastructure import Packet
 from bomi.device_managers.protocols import SupportsGetSensorMetadata, SupportsHasSensors, SupportsStreaming, HasDiscoverDevicesSignal, HasChannelLabels, HasInputKind
 from queue import Queue
 from typing import Protocol, Iterable
@@ -106,7 +107,7 @@ class QtmDeviceManager(QObject):
         return ["QTM"]
 
     # def start_stream(self): #for debugging with if __name__ == '__main__':
-    def start_stream(self, queue: Queue) -> None:
+    def start_stream(self, queue: Queue[Packet]) -> None:
         """
         Start streaming data to the passed in queue
         """

--- a/bomi/device_managers/yost_manager.py
+++ b/bomi/device_managers/yost_manager.py
@@ -9,6 +9,7 @@ import threading
 import time
 
 import threespace_api as ts_api
+from bomi.datastructure import Packet
 from bomi.device_managers.yost_serial_comm import (
     Dongles,
     WiredSensors,
@@ -180,7 +181,7 @@ class YostDeviceManager(QObject):
         _print(f"{serial_number_hex} nicknamed {name}")
         self._names[serial_number_hex] = name
 
-    def start_stream(self, queue: Queue):
+    def start_stream(self, queue: Queue[Packet]):
         if not self.has_sensors():
             _print("No sensors found. Aborting stream")
             return
@@ -285,7 +286,7 @@ class YostDeviceManager(QObject):
 
 
 def _handle_stream(
-    queue: Queue,
+    queue: Queue[Packet],
     done: threading.Event,
     fs: int,
     sensor_port_names: List[str],

--- a/bomi/scope_widget.py
+++ b/bomi/scope_widget.py
@@ -603,10 +603,9 @@ class ScopeWidget(qw.QWidget):
 
         for _ in range(qsize):  # process current items in queue
             packet = q.get()
-            
-            name = packet["Name"]
+
             try:
-                buffer = self.buffers[name]
+                buffer = self.buffers[packet.device_name]
             except KeyError:
                 # When we select a single sensor,
                 # the device manager will still populate the queue

--- a/bomi/scope_widget.py
+++ b/bomi/scope_widget.py
@@ -16,7 +16,7 @@ from pyqtgraph.parametertree.parameterTypes import ActionParameter
 from pyqtgraph.parametertree.parameterTypes.basetypes import Parameter
 
 from bomi.base_widgets import TaskEvent, TaskDisplay, generate_edit_form
-from bomi.datastructure import MultichannelBuffer, SubjectMetadata
+from bomi.datastructure import MultichannelBuffer, SubjectMetadata, Packet
 from bomi.device_managers.protocols import (
     SupportsStreaming,
     SupportsGetSensorMetadata,
@@ -214,7 +214,7 @@ class ScopeWidget(qw.QWidget):
         else:
             self.trigno_client = None
 
-        self.queue: Queue = Queue()
+        self.queue: Queue[Packet] = Queue()
 
         self.dev_names: List[str] = []  # device name/nicknames
         self.dev_sn: List[str] = []  # device serial numbers (hex str)


### PR DESCRIPTION
In the 0.3.0 refactoring, I replaced the yost packet data type with dictionaries so that it was generalized to any device manager.

This was a bit of a hacky solution, as the buffer and scope widget expect certain fields, and there was no good way to document/specify this.

With a new, generalized Packet class, we specify that implementing device mangers should put Packet objects that have fields `time`, `device_name`, and `channel_readings` into the passed-in queue.